### PR TITLE
fix: guard clause to `handleEditabeFocus`

### DIFF
--- a/src/panel/components/PunctuationSection.vue
+++ b/src/panel/components/PunctuationSection.vue
@@ -64,8 +64,12 @@ export default {
       const element = event.target;
 
       if (element.isContentEditable) {
+        const selection = window.getSelection();
+        if (selection.rangeCount === 0) {
+          return;
+        }
         this.lastFocusedElement = element;
-        this.lastSelection = window.getSelection().getRangeAt(0).cloneRange();
+        this.lastSelection = selection.getRangeAt(0).cloneRange();
       }
     },
 


### PR DESCRIPTION
### Description

This PR resolves a JavaScript `IndexSizeError` that can occur when a user focuses on a `contenteditable` field in the Panel.

The error appears to be caused by a race condition where the `handleEditabeFocus` event listener is triggered before the browser has created a selection range. Attempting to call `window.getSelection().getRangeAt(0)` on an empty selection throws the error.

### The Fix

The solution is to introduce a guard clause that checks if `selection.rangeCount` is greater than 0 before proceeding. If no selection range exists, the function exits early, preventing the error without affecting functionality.